### PR TITLE
Implement float32, float64 to []byte AND vise versa

### DIFF
--- a/conversion.go
+++ b/conversion.go
@@ -3,7 +3,20 @@ package conversion
 
 import (
 	"fmt"
+
+	"encoding/binary"
+	"errors"
+	"math"
 )
+
+type Endian int
+
+const BigEndian Endian = 0
+const LittleEndian Endian = 1
+
+type Option struct {
+	Endian Endian
+}
 
 // IntToFloat32 converts int to float32
 func IntToFloat32(x int) (float32, error) {
@@ -56,4 +69,64 @@ func unflattenInternal(xs []byte, size int) ([][]byte, error) {
 	}
 
 	return ret, nil
+}
+
+// Float32ToBytes converts float32 to []byte with length 4
+func Float32ToBytes(x float32, o *Option) []byte {
+	b := make([]byte, 4)
+	ux := math.Float32bits(x)
+	if o == nil || o.Endian == BigEndian {
+		binary.BigEndian.PutUint32(b, ux)
+	} else {
+		binary.LittleEndian.PutUint32(b, ux)
+	}
+	return b
+}
+
+// BytesToFloat32 converts []byte to float32
+// length of []byte should be 4 or bigger
+func BytesToFloat32(x []byte, o *Option) (float32, error) {
+	var fx float32
+
+	if len(x) < 4 {
+		return fx, errors.New("length of []byte should be 4 or bigger")
+	}
+
+	var ux uint32
+	if o == nil || o.Endian == BigEndian {
+		ux = binary.BigEndian.Uint32(x)
+	} else {
+		ux = binary.LittleEndian.Uint32(x)
+	}
+	return math.Float32frombits(ux), nil
+}
+
+// Float64ToBytes converts float64 to []byte with length 8
+func Float64ToBytes(x float64, o *Option) []byte {
+	b := make([]byte, 8)
+	ux := math.Float64bits(x)
+	if o == nil || o.Endian == BigEndian {
+		binary.BigEndian.PutUint64(b, ux)
+	} else {
+		binary.LittleEndian.PutUint64(b, ux)
+	}
+	return b
+}
+
+// BytesToFloat64 converts []byte to float64
+// length of []byte should be 8 or bigger
+func BytesToFloat64(x []byte, o *Option) (float64, error) {
+	var fx float64
+
+	if len(x) < 8 {
+		return fx, errors.New("length of []byte should be 4 or bigger")
+	}
+
+	var ux uint64
+	if o == nil || o.Endian == BigEndian {
+		ux = binary.BigEndian.Uint64(x)
+	} else {
+		ux = binary.LittleEndian.Uint64(x)
+	}
+	return math.Float64frombits(ux), nil
 }

--- a/conversion_test.go
+++ b/conversion_test.go
@@ -4,8 +4,14 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+
 	"testing"
+
+	"log"
 )
+
+var optBig = &Option{Endian: BigEndian}
+var optLittle = &Option{Endian: LittleEndian}
 
 func ExampleIntToFloat32() {
 	var x int = 3
@@ -155,4 +161,41 @@ func Example_unflattenBytes64() {
 	xs := []byte{1, 2, 3, 4, 5, 6, 7, 8}
 	fmt.Print(unflattenBytes64(xs))
 	// Output: [[1 2 3 4 5 6 7 8]] <nil>
+}
+
+func ExampleFloat32ToBytes() {
+	x := float32(-561.2863) // -561.2863, 0xc40c5253
+	bs := Float32ToBytes(x, optBig)
+	fmt.Printf("%#02v\n", bs)
+	// Output: []byte{0xc4, 0x0c, 0x52, 0x53}
+}
+
+func ExampleBytesToFloat32() {
+	xs := []byte{0xc4, 0x0c, 0x52, 0x53} // -561.2863, 0xc40c5253
+	fx, err := BytesToFloat32(xs, optBig)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Printf("%v\n", fx)
+	// Output: -561.2863
+}
+
+func ExampleFloat64ToBytes() {
+	x := float64(-561.2863) // -561.2863, 0xc0818a4a57a786c2
+	bs := Float64ToBytes(x, optBig)
+	fmt.Printf("%#02v\n", bs)
+	// Output: []byte{0xc0, 0x81, 0x8a, 0x4a, 0x57, 0xa7, 0x86, 0xc2}
+}
+
+func ExampleBytesToFloat64() {
+	xs := []byte{0xc0, 0x81, 0x8a, 0x4a, 0x57, 0xa7, 0x86, 0xc2} // -561.2863, 0xc0818a4a57a786c2
+	fx, err := BytesToFloat64(xs, optBig)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Printf("%v\n", fx)
+	// Output: -561.2863
+
 }

--- a/conversion_test.go
+++ b/conversion_test.go
@@ -168,6 +168,7 @@ func ExampleFloat32ToBytes() {
 	bs := Float32ToBytes(x, optBig)
 	fmt.Printf("%#02v\n", bs)
 	// Output: []byte{0xc4, 0x0c, 0x52, 0x53}
+	// []byte{0x53, 0x52, 0x0c, 0xc4}
 }
 
 func ExampleBytesToFloat32() {


### PR DESCRIPTION
Implemented and tested with Example

func Float32ToBytes(x float32, o *Option) ([]byte, error)
func BytesToFloat32(x []byte, o *Option) (float32, error)
func Float64ToBytes(x float64, o *Option) ([]byte, error)
func BytesToFloat64(x []byte, o *Option) (float64, error)