### PR TITLE
enhance: less byte slice size managed by package, so no need for error

### DIFF
--- a/conversion.go
+++ b/conversion.go
@@ -5,7 +5,6 @@ import (
 	"github.com/deepbaksu/conversion/internal"
 
 	"encoding/binary"
-	"errors"
 	"math"
 )
 
@@ -38,21 +37,22 @@ func Float32ToBytes(x float32, o *Option) []byte {
 }
 
 // BytesToFloat32 converts []byte to float32
-// length of []byte should be 4 or bigger
-func BytesToFloat32(x []byte, o *Option) (float32, error) {
-	var fx float32
+// only 4 or less bytes will be converted
+func BytesToFloat32(x []byte, o *Option) float32 {
+	var bytes []byte
 
 	if len(x) < 4 {
-		return fx, errors.New("length of []byte should be 4 or bigger")
+		bytes = make([]byte, 4-len(x))
 	}
+	bytes = append(bytes, x...)
 
 	var ux uint32
 	if o == nil || o.Endian == BigEndian {
-		ux = binary.BigEndian.Uint32(x)
+		ux = binary.BigEndian.Uint32(bytes)
 	} else {
-		ux = binary.LittleEndian.Uint32(x)
+		ux = binary.LittleEndian.Uint32(bytes)
 	}
-	return math.Float32frombits(ux), nil
+	return math.Float32frombits(ux)
 }
 
 // Float64ToBytes converts float64 to []byte with length 8
@@ -68,21 +68,22 @@ func Float64ToBytes(x float64, o *Option) []byte {
 }
 
 // BytesToFloat64 converts []byte to float64
-// length of []byte should be 8 or bigger
-func BytesToFloat64(x []byte, o *Option) (float64, error) {
-	var fx float64
+// only 4 or less bytes will be converted
+func BytesToFloat64(x []byte, o *Option) float64 {
+	var bytes []byte
 
 	if len(x) < 8 {
-		return fx, errors.New("length of []byte should be 8 or bigger")
+		bytes = make([]byte, 8-len(x))
 	}
+	bytes = append(bytes, x...)
 
 	var ux uint64
 	if o == nil || o.Endian == BigEndian {
-		ux = binary.BigEndian.Uint64(x)
+		ux = binary.BigEndian.Uint64(bytes)
 	} else {
-		ux = binary.LittleEndian.Uint64(x)
+		ux = binary.LittleEndian.Uint64(bytes)
 	}
-	return math.Float64frombits(ux), nil
+	return math.Float64frombits(ux)
 }
 
 // Float32sToBytes converts []float32 to []byte.
@@ -107,11 +108,7 @@ func BytesToFloat32s(xs []byte, o *Option) ([]float32, error) {
 	}
 
 	for _, xs := range xxs {
-		xs, err := BytesToFloat32(xs, o)
-		if err != nil {
-			return nil, err
-		}
-		fs = append(fs, xs)
+		fs = append(fs, BytesToFloat32(xs, o))
 	}
 
 	return fs, nil
@@ -139,11 +136,7 @@ func BytesToFloat64s(xs []byte, o *Option) ([]float64, error) {
 	}
 
 	for _, xs := range xxs {
-		xs, err := BytesToFloat64(xs, o)
-		if err != nil {
-			return nil, err
-		}
-		fs = append(fs, xs)
+		fs = append(fs, BytesToFloat64(xs, o))
 	}
 
 	return fs, nil

--- a/conversion_test.go
+++ b/conversion_test.go
@@ -9,8 +9,6 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"testing"
-
-	"log"
 )
 
 var (
@@ -58,26 +56,12 @@ func ExampleFloat32ToBytes() {
 
 func ExampleBytesToFloat32() {
 	xs := []byte{0xc4, 0x0c, 0x52, 0x53} // -561.2863, 0xc40c5253
-	fx, err := BytesToFloat32(xs, optBig)
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	fmt.Printf("%v\n", fx)
+	fmt.Println(BytesToFloat32(xs, optBig))
 	// Output: -561.2863
 }
-
-func TestBytesToFloat32_failBadInput(t *testing.T) {
-	// bad input as 32bits should have a length of 4.
-	xs := []byte{0xc4, 0x0c, 0x52}
-	_, err := BytesToFloat32(xs, optBig)
-	assert.EqualError(t, err, "length of []byte should be 4 or bigger")
-}
-
 func TestBytesToFloat32_littleEndian(t *testing.T) {
 	xs := []byte{0x53, 0x52, 0x0c, 0xc4} // -561.2863
-	fx, err := BytesToFloat32(xs, optLittle)
-	assert.NoError(t, err)
+	fx := BytesToFloat32(xs, optLittle)
 	assert.InEpsilon(t, -561.2863, fx, 1e-4)
 }
 
@@ -96,25 +80,12 @@ func TestFloat64ToBytes_littleEndian(t *testing.T) {
 
 func ExampleBytesToFloat64() {
 	xs := []byte{0xc0, 0x81, 0x8a, 0x4a, 0x57, 0xa7, 0x86, 0xc2} // -561.2863, 0xc0818a4a57a786c2
-	fx, err := BytesToFloat64(xs, optBig)
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	fmt.Printf("%v\n", fx)
+	fmt.Println(BytesToFloat64(xs, optBig))
 	// Output: -561.2863
 }
-
-func TestBytesToFloat64_invalidInput(t *testing.T) {
-	invalidInput := []byte{0x1, 0x2, 0x3}
-	_, err := BytesToFloat64(invalidInput, nil)
-	assert.EqualError(t, err, "length of []byte should be 8 or bigger")
-}
-
 func TestBytesToFloat64_littleEndian(t *testing.T) {
 	xs := []byte{0xc2, 0x86, 0xa7, 0x57, 0x4a, 0x8a, 0x81, 0xc0} // -561.2863, 0xc0818a4a57a786c2
-	fx, err := BytesToFloat64(xs, optLittle)
-	assert.NoError(t, err)
+	fx := BytesToFloat64(xs, optLittle)
 	assert.InEpsilon(t, -561.2863, fx, 1e-4)
 }
 


### PR DESCRIPTION
- enhance: IntToFloat32 has no possible error
- enhance: less byte slice size managed by package

Maybe it is over engineering or it is better leave error for future useage
I will follow reviewer's opinion
